### PR TITLE
Updating package dependencies to support 2.x and 3.x of Hapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "handlebars": "1.3.x"
   },
   "peerDependencies": {
-    "hapi": "3.x.x"
+    "hapi": ">2.x.x"
   },
   "devDependencies": {
-    "hapi": "3.x.x",
+    "hapi": ">2.x.x",
     "lab": "1.x.x"
   },
   "scripts": {


### PR DESCRIPTION
Updating the package.json file to utilize 3.x.x. All tests still passed via Lab and worked when tested against my Hapi 3.x app. 
