### PR TITLE
Add public-host option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.register = function (plugin, options, next) {
 
         var context = {
             endpoint: settings.endpoint,
-            host: settings.host || server.info.host,
+            host: settings.publicHost || settings.host || server.info.host,
             port: server.info.port
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,37 @@ describe('Tv', function () {
             done();
         });
     });
+
+    it('uses specified public hostname', function (done) {
+
+        var server = new Hapi.Server(0);
+
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) {
+
+                reply('1');
+            }
+        });
+
+        server.pack.register({ plugin: Tv, options: { port: 0, host: 'localhost', publicHost: '127.0.0.1' }}, function (err) {
+
+            expect(err).to.not.exist;
+
+            server.inject('/debug/console', function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result).to.contain('Debug Console');
+
+                var host = res.result.match(/var host = '([^']+)'/)[1];
+
+                expect(host).to.equal('127.0.0.1');
+                done();
+
+            });
+        });
+    });
 });
 
 


### PR DESCRIPTION
This feature is needed to support servers with different private and
public ip addresses, e.g. Amazon EC2 instances.

Reference:
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html
