### PR TITLE
Moved assignment of .tv property to first received event #92

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,8 +95,6 @@ exports.register = function (server, options, next) {
 
             var key = settings.queryKey;
             if (request.query[key]) {
-                request.plugins.tv = { debugId: request.query[key] };
-
                 delete request.query[key];
                 delete request.url.search;
                 delete request.url.query[key];
@@ -139,7 +137,15 @@ exports.register = function (server, options, next) {
         };
 
         server.on('request', onLog);
-        server.on('request-internal', onLog);
+        server.on('request-internal', function(request, event, tags) {
+            
+            var key = settings.queryKey;
+            if (tags.received && request.query[key] && !request.plugins.tv) {            // first internal event has tag received: true
+                request.plugins.tv = { debugId: request.query[key] };
+            }
+            
+            onLog(request, event, tags);
+        });
         server.on('response', function (request) {
 
             var event = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,8 +93,10 @@ exports.register = function (server, options, next) {
 
         server.ext('onRequest', function (request, reply) {
 
-            var key = settings.queryKey;
-            if (request.query[key]) {
+            if (request.plugins.tv && request.plugins.tv.debugId) {
+                
+                var key = settings.queryKey;
+
                 delete request.query[key];
                 delete request.url.search;
                 delete request.url.query[key];


### PR DESCRIPTION
This moves the assignment of `request.plugins.tv` to the `request-internals` hook and only executes when `tags.received = true`, which represents the first log in the request/response stack.

For what it's worth, I tried hooking this into the `server.on('request')` event, but it seems to not fire during a normal request.
