### PR TITLE
Let the browser pick the protocol accordingly.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
         <meta http-equiv="Content-Language" content="en-us">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <link href="{{ endpoint }}/css/style.css" rel="stylesheet">
-        <link href="http://fonts.googleapis.com/css?family=PT+Mono|Open+Sans:300,400,600" rel="stylesheet" type="text/css">
+        <link href="//fonts.googleapis.com/css?family=PT+Mono|Open+Sans:300,400,600" rel="stylesheet" type="text/css">
         <style class="cursor-styles"></style>
     </head>
     <body>


### PR DESCRIPTION
I'm using HTTPS to serve my API, since the fonts were being loaded using HTTP, most browsers blocked the connection due to mixed-content.