### PR TITLE
Fix #109, make tv work with routes prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ exports.register = function (server, options, next) {
                 handler: function (request, reply) {
 
                     var context = {
-                        endpoint: settings.endpoint,
+                        endpoint: request.path,
                         host: host,
                         port: tv.info.port
                     };

--- a/test/index.js
+++ b/test/index.js
@@ -371,18 +371,18 @@ it('uses specified route prefix for assets', function (done) {
         }
     });
 
-    server.register({ register: Tv, options: { port: 0 }}, { routes: { prefix: '/test'} }, function (err) {
+    server.register({ register: Tv, options: { port: 0 } }, { routes: { prefix: '/test' } }, function (err) {
 
         expect(err).to.not.exist();
 
         server.inject('/test/debug/console', function (res) {
-            var cssPath = 'href="' + res.request.path + '/css/style.css';
-            var jsPath = 'src="' + res.request.path + '/js/main.js';
 
             expect(res.statusCode).to.equal(200);
+
+            var cssPath = 'href="' + res.request.path + '/css/style.css';
+            var jsPath = 'src="' + res.request.path + '/js/main.js';
             expect(res.result).to.contain(cssPath);
             expect(res.result).to.contain(jsPath);
-
             done();
 
         });

--- a/test/index.js
+++ b/test/index.js
@@ -355,3 +355,36 @@ it('defaults to os hostname if unspecified', function (done) {
         });
     });
 });
+
+
+it('uses specified route prefix for assets', function (done) {
+
+    var server = new Hapi.Server();
+    server.connection();
+
+    server.route({
+        method: 'GET',
+        path: '/',
+        handler: function (request, reply) {
+
+            return reply('1');
+        }
+    });
+
+    server.register({ register: Tv, options: { port: 0 }}, { routes: { prefix: '/test'} }, function (err) {
+
+        expect(err).to.not.exist();
+
+        server.inject('/test/debug/console', function (res) {
+            var cssPath = 'href="' + res.request.path + '/css/style.css';
+            var jsPath = 'src="' + res.request.path + '/js/main.js';
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.contain(cssPath);
+            expect(res.result).to.contain(jsPath);
+
+            done();
+
+        });
+    });
+});


### PR DESCRIPTION
I'm really dubious about the way it tests the asset path, but it's a start I guess.