### PR TITLE
Remove iojs from travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
-  - iojs


### PR DESCRIPTION
To help prevent compatibility errors and hapi itself doesn't support iojs. Also helps with #111 on errors between a module and iojs latest stable version.