### PR TITLE
Set address for Hapi connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ In applications using multiple server instances, only one server can enable the 
 
 Below are the options available to be passed into the **tv** plugin:
 
-- `host` - the hostname, IP address, or path to UNIX domain socket the WebSocket connection is bound to. Defaults to _undefined_ and therefore `0.0.0.0`
-   which means any available network interface(see hapi `new Server()`).
+- `host` - the public hostname or IP address. Used only to set `server.info.host` and `server.info.uri`.
+   Deaults to hostname and if not available to `localhost`(see hapi `new Server()`).
+- `address` - the hostname of IP address the WebSocket connection will bind to. Defaults to `host` if present otherwise `0.0.0.0`(see hapi `new Server()`).
 - `port` - the port used by the WebSocket connection. Defaults to _0_ and therefore an ephemeral port (see hapi `new Server()`).
 - `endpoint` - the debug console request path added to the server routes. Defaults to _'/debug/console'_.
 - `queryKey` - the name or the request query parameter used to mark requests being debugged. Defaults to _debug_.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ internals.defaults = {
     queryKey: 'debug',
     template: 'index',
     host: undefined,
+    address: undefined,
     authenticateEndpoint: false,
     port: 0
 };
@@ -53,7 +54,7 @@ exports.register = function (server, options, next) {
 
     var subscribers = {};                                                   // Map: debug session -> [ subscriber ]
     var tv = new Hapi.Server();
-    tv.connection({ host: settings.host, port: settings.port });
+    tv.connection({ host: settings.host, address: settings.address, port: settings.port });
 
     tv.start(function () {
 

--- a/test/index.js
+++ b/test/index.js
@@ -327,6 +327,37 @@ it('uses specified public hostname', function (done) {
     });
 });
 
+it('binds to address and uses host as public hostname', function (done) {
+
+    var server = new Hapi.Server();
+    server.connection();
+
+    server.route({
+        method: 'GET',
+        path: '/',
+        handler: function (request, reply) {
+
+            return reply('1');
+        }
+    });
+
+    server.register([Vision, Inert, { register: Tv, options: { port: 0, host: 'aaaaa', address: '127.0.0.1' } }], function (err) {
+
+        expect(err).to.not.exist();
+
+        server.inject('/debug/console', function (res) {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.contain('Debug Console');
+
+            var host = res.result.match(/var host = '([^']+)'/)[1];
+            expect(host).to.equal('aaaaa');
+            done();
+
+        });
+    });
+});
+
 it('defaults to os hostname if unspecified', function (done) {
 
     var server = new Hapi.Server();


### PR DESCRIPTION
Allow setting the `address` connection option for `tv`, listed in the [connectionoptions](http://hapijs.com/api#serverconnectionoptions). This is required if you would like to run `tv` inside a Docker container without allowing it to use the host network. 
